### PR TITLE
Simple, small ant build file with ant-javacard

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project basedir="." default="applet" name="ledger-u2f-javacard">
+  <target name="applet">
+    <get src="https://github.com/martinpaljak/ant-javacard/releases/download/v1.4/ant-javacard.jar" skipexisting="true" dest="."/>
+    <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ant-javacard.jar"/>
+    <javacard>
+      <cap output="U2FApplet.cap" sources="src" aid="a0:00:00:06:17:00:4f:97:a2:e9:50:01">
+        <applet class="com.ledger.u2f.U2FApplet" aid="a0:00:00:06:17:00:4f:97:a2:e9:49:01"/>
+      </cap>
+    </javacard>
+  </target>
+</project>


### PR DESCRIPTION
Does not require a 40M download to get the small task done. Just issue `JC_HOME=/path/to/jckit ant` and you get:

```
$ JC_HOME=../jc303_kit ant
Buildfile: /home/martin/projects/ledger-u2f-javacard/build.xml

applet:
      [get] Getting: https://github.com/martinpaljak/ant-javacard/releases/download/v1.4/ant-javacard.jar
      [get] To: /home/martin/projects/ledger-u2f-javacard/ant-javacard.jar
      [get] https://github.com/martinpaljak/ant-javacard/releases/download/v1.4/ant-javacard.jar moved to https://github-cloud.s3.amazonaws.com/releases/28853876/9393fbbe-bacc-11e5-81bd-18bf99a74455.jar?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAISTNZFOVBIJMK3TQ%2F20160123%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20160123T202910Z&X-Amz-Expires=300&X-Amz-Signature=22cf0c32a4e5d7756c0ebc16aa3726eaf3594a869b36cb29510f4ddaa7f425ca&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B%20filename%3Dant-javacard.jar&response-content-type=application%2Foctet-stream
      [cap] INFO: using JavaCard v3.x SDK in ../jc303_kit
      [cap] Setting package name to com.ledger.u2f
      [cap] Building CAP with 1 applet from package com.ledger.u2f
      [cap] com.ledger.u2f.U2FApplet A000000617004F97A2E94901
  [compile] Compiling 5 source files to /tmp/antjc437675988945415981
      [cap] [ INFO: ] Converter [v3.0.3]
      [cap] [ INFO: ]     Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
      [cap]     
      [cap]     
      [cap] [ INFO: ] conversion completed with 0 errors and 0 warnings.
      [cap] CAP saved to /home/martin/projects/ledger-u2f-javacard/U2FApplet.cap

BUILD SUCCESSFUL
Total time: 3 seconds
```
