### PR TITLE
Make non-final fields not static.

### DIFF
--- a/src/main/java/com/ledger/u2f/FIDOStandalone.java
+++ b/src/main/java/com/ledger/u2f/FIDOStandalone.java
@@ -33,12 +33,12 @@ import javacard.framework.Util;
 
 public class FIDOStandalone implements FIDOAPI {
 
-    private static KeyPair keyPair;
-    private static AESKey chipKey;
-    private static Cipher cipherEncrypt;
-    private static Cipher cipherDecrypt;
-    private static RandomData random;
-    private static byte[] scratch;
+    private KeyPair keyPair;
+    private AESKey chipKey;
+    private Cipher cipherEncrypt;
+    private Cipher cipherDecrypt;
+    private RandomData random;
+    private byte[] scratch;
 
     private static final byte[] IV_ZERO_AES = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 

--- a/src/main/java/com/ledger/u2f/U2FApplet.java
+++ b/src/main/java/com/ledger/u2f/U2FApplet.java
@@ -35,19 +35,19 @@ import javacard.security.CryptoException;
 
 public class U2FApplet extends Applet implements ExtendedLength {
 
-    private static byte flags;
-    private static byte[] counter;
-    private static byte[] scratchPersistent;
-    private static byte[] scratch;
-    private static byte[] attestationCertificate;
-    private static boolean attestationCertificateSet;
-    private static ECPrivateKey attestationPrivateKey;
-    private static ECPrivateKey localPrivateKey;
-    private static boolean localPrivateTransient;
-    private static boolean counterOverflowed;
-    private static Signature attestationSignature;
-    private static Signature localSignature;
-    private static FIDOAPI fidoImpl;
+    private byte flags;
+    private byte[] counter;
+    private byte[] scratchPersistent;
+    private byte[] scratch;
+    private byte[] attestationCertificate;
+    private boolean attestationCertificateSet;
+    private ECPrivateKey attestationPrivateKey;
+    private ECPrivateKey localPrivateKey;
+    private boolean localPrivateTransient;
+    private boolean counterOverflowed;
+    private Signature attestationSignature;
+    private Signature localSignature;
+    private FIDOAPI fidoImpl;
 
     private static final byte VERSION[] = { 'U', '2', 'F', '_', 'V', '2' };
 


### PR DESCRIPTION
With static non-final fields, the applet would not be installable in multiple instances, also it is unreasonable to have those fields static(apart from possible minor performance gain on some cards) and makes for a testing nightmare.