### PR TITLE
Updated required JC version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It uses no proprietary vendor API and is freely available on [Ledger Unplugged](
 
 # Building 
 
-  - Set the environment variable `JC_HOME` to the folder containg the [Java Card Development Kit 3.0.2](http://www.oracle.com/technetwork/java/embedded/javacard/downloads/index.html)
+  - Set the environment variable `JC_HOME` to the folder containg the [Java Card Development Kit 3.0.5](http://www.oracle.com/technetwork/java/embedded/javacard/downloads/index.html)
   - Run `gradlew convertJavacard`
 
 # Installing 

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     // testCompile group: 'junit', name: 'junit', version: '4.12'
     // testCompile 'org.testng:testng:6.1.1'
 
-    jcardsim 'com.licel:jcardsim:3.0.4'
+    jcardsim 'com.licel:jcardsim:3.0.5'
 }
 
 test {
@@ -44,15 +44,10 @@ test {
 }
 
 // JavaCard SDKs and libraries
-final def JC212 = libsSdk + '/jc212_kit'
-final def JC221 = libsSdk + '/jc221_kit'
-final def JC222 = libsSdk + '/jc222_kit'
-final def JC303 = libsSdk + '/jc303_kit'
-final def JC304 = libsSdk + '/jc304_kit'
 final def JC305 = libsSdk + '/jc305u1_kit'
 
 // Which JavaCard SDK to use - select
-final def JC_SELECTED = JC304
+final def JC_SELECTED = JC305
 
 javacard {
 


### PR DESCRIPTION
8b9ca412ab52d76958f9a0df85f32431cd2fd344 merged in #8 makes use of `RandomData.ALG_KEYGENERATION` introduced in JC 3.0.5 in place of `RandomData.ALG_SECURE_RANDOM`, so updated docs accordingly.